### PR TITLE
Support empty translation strings

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -887,7 +887,7 @@ module.exports = (function() {
     var mutator = localeMutator(locale, singular);
 
     if (plural) {
-      if (!accessor()) {
+      if (accessor() == null) {
         mutator({
           'one': defaultSingular || singular,
           'other': defaultPlural || plural
@@ -896,7 +896,7 @@ module.exports = (function() {
       }
     }
 
-    if (!accessor()) {
+    if (accessor() == null) {
       mutator(defaultSingular || singular);
       write(locale);
     }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,5 @@
 {
+	"Empty": "",
 	"Hello": "Hello",
 	"Hello %s, how are you today?": "Hello %s, how are you today?",
 	"weekend": "weekend",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iflix/i18n",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iflix/i18n",
   "description": "Lightweight translation module with dynamic json storage",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "homepage": "https://github.com/iflix-letsplay/i18n-node",
   "repository": {
     "type": "git",

--- a/test/i18n.api.global.js
+++ b/test/i18n.api.global.js
@@ -61,6 +61,11 @@ describe('Module API', function() {
     });
 
     describe('i18nTranslate', function() {
+      it('should return an empty string if the translation is an empty string', function() {
+        i18n.setLocale('en');
+        should.equal(__('Empty'), '');
+      });
+
       it('should return en translations as expected', function() {
         i18n.setLocale('en');
         should.equal(__('Hello'), 'Hello');

--- a/test/i18n.api.local.js
+++ b/test/i18n.api.local.js
@@ -172,6 +172,13 @@ describe('Module API', function () {
         afterEach(function() {
           i18n.setLocale('en');
         });
+
+        it('should return an empty string if the translation is an empty string', function(done) {
+          i18n.setLocale(req, 'en').should.equal('en');
+          req.__('Empty').should.equal('');
+          done();
+        });
+
         it('has to use local translation in en', function (done) {
           i18n.setLocale(req, 'en').should.equal('en');
           req.__('Hello').should.equal('Hello');

--- a/test/i18n.missingPhrases.js
+++ b/test/i18n.missingPhrases.js
@@ -1,0 +1,69 @@
+/*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
+
+// now with coverage suport
+var i18n = require('../i18n'),
+    should = require("should");
+
+describe('Missing Phrases', function () {
+
+  beforeEach(function() {
+
+    i18n.configure({
+      locales: ['en', 'de'],
+      fallbacks: {'nl': 'de'},
+      directory: './locales',
+      updateFiles: false,
+      syncFiles: false
+    });
+
+  });
+
+  describe('Local Module API', function () {
+    var req = {
+      request: "GET /test",
+      __: i18n.__,
+      __n: i18n.__n,
+      locale: {},
+      headers: {}
+    };
+
+    beforeEach(function() {
+      i18n.configure({
+        locales: ['en', 'de', 'en-GB'],
+        defaultLocale: 'en',
+        directory: './locales',
+        register: req,
+        updateFiles: false,
+        syncFiles: false
+      });
+    });
+
+    describe('i18nTranslate', function () {
+      it('should return the key if the translation does not exist', function(done) {
+        i18n.setLocale(req, 'en').should.equal('en');
+        req.__('DoesNotExist').should.equal('DoesNotExist');
+        done();
+      });
+    });
+  });
+
+  describe('Global Module API', function () {
+    beforeEach(function() {
+      i18n.configure({
+        locales: ['en', 'de', 'en-GB'],
+        defaultLocale: 'en',
+        directory: './locales',
+        register: global,
+        updateFiles: false,
+        syncFiles: false
+      });
+    });
+
+    describe('i18nTranslate', function () {
+      it('should return the key if the translation does not exist', function() {
+        i18n.setLocale('en');
+        should.equal(__('DoesNotExist'), 'DoesNotExist');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request fixes that by only replacing with the key if the translation key does not exist, rather than being empty string (was a basic falsey check where it should've been a check for null/undefined).

Also added some tests for this use case.